### PR TITLE
Add Eagle library for Nodemcu v0.9

### DIFF
--- a/ESP12_DEVKIT.lbr
+++ b/ESP12_DEVKIT.lbr
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE eagle SYSTEM "eagle.dtd">
+<eagle version="7.3.0">
+<drawing>
+<settings>
+<setting alwaysvectorfont="no"/>
+<setting verticaltext="up"/>
+</settings>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<layers>
+<layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="20" name="Dimension" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="yes"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="yes"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="yes"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="yes"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="yes"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="yes" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="yes" active="yes"/>
+<layer number="91" name="Nets" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="92" name="Busses" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="93" name="Pins" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="94" name="Symbols" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="95" name="Names" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="96" name="Values" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="97" name="Info" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="98" name="Guide" color="6" fill="1" visible="yes" active="yes"/>
+</layers>
+<library>
+<packages>
+<package name="ESP12_DEVKIT">
+<description>ESP12_DEVKIT</description>
+<wire x1="-15.24" y1="-19.05" x2="-15.24" y2="21.23" width="0.2032" layer="51"/>
+<wire x1="-12.7" y1="-21.59" x2="-3.81" y2="-21.59" width="0.2032" layer="51"/>
+<wire x1="-3.81" y1="-21.59" x2="3.81" y2="-21.59" width="0.2032" layer="51"/>
+<wire x1="3.81" y1="-21.59" x2="12.7" y2="-21.59" width="0.2032" layer="51"/>
+<wire x1="-11.43" y1="25.04" x2="-7.62" y2="25.04" width="0.2032" layer="51"/>
+<wire x1="-7.62" y1="25.04" x2="7.62" y2="25.04" width="0.2032" layer="51"/>
+<wire x1="7.62" y1="25.04" x2="11.43" y2="25.04" width="0.2032" layer="51"/>
+<wire x1="15.24" y1="21.23" x2="15.24" y2="-19.05" width="0.2032" layer="51"/>
+<wire x1="15.24" y1="21.23" x2="11.43" y2="25.04" width="0.2032" layer="51"/>
+<wire x1="-15.24" y1="21.23" x2="-11.43" y2="25.04" width="0.2032" layer="51"/>
+<wire x1="-12.7" y1="-21.59" x2="-15.24" y2="-19.05" width="0.2032" layer="51"/>
+<wire x1="12.7" y1="-21.59" x2="15.24" y2="-19.05" width="0.2032" layer="51"/>
+<pad name="A0" x="-13.97" y="17.78" drill="0.8" diameter="1.9304"/>
+<pad name="RSV@0" x="-13.97" y="15.24" drill="0.8" diameter="1.9304"/>
+<pad name="RSV@1" x="-13.97" y="12.7" drill="0.8" diameter="1.9304"/>
+<pad name="RSV@2" x="-13.97" y="10.16" drill="0.8" diameter="1.9304"/>
+<pad name="RSV@3" x="-13.97" y="7.62" drill="0.8" diameter="1.9304"/>
+<pad name="RSV@4" x="-13.97" y="5.08" drill="0.8" diameter="1.9304"/>
+<pad name="RSV@5" x="-13.97" y="2.54" drill="0.8" diameter="1.9304"/>
+<pad name="GND@4" x="-13.97" y="0" drill="0.8" diameter="1.9304"/>
+<pad name="3V3@3" x="-13.97" y="-2.54" drill="0.8" diameter="1.9304"/>
+<pad name="GND@0" x="-13.97" y="-5.08" drill="0.8" diameter="1.9304"/>
+<pad name="3V3@0" x="-13.97" y="-7.62" drill="0.8" diameter="1.9304"/>
+<pad name="EN" x="-13.97" y="-10.16" drill="0.8" diameter="1.9304"/>
+<pad name="RST" x="-13.97" y="-12.7" drill="0.8" diameter="1.9304"/>
+<pad name="GND@1" x="-13.97" y="-15.24" drill="0.8" diameter="1.9304"/>
+<pad name="5V" x="-13.97" y="-17.78" drill="0.8" diameter="1.9304"/>
+<pad name="D0" x="13.97" y="17.78" drill="0.8" diameter="1.9304"/>
+<pad name="D1" x="13.97" y="15.24" drill="0.8" diameter="1.9304"/>
+<pad name="D2" x="13.97" y="12.7" drill="0.8" diameter="1.9304"/>
+<pad name="D3" x="13.97" y="10.16" drill="0.8" diameter="1.9304"/>
+<pad name="D4" x="13.97" y="7.62" drill="0.8" diameter="1.9304"/>
+<pad name="3V3@1" x="13.97" y="5.08" drill="0.8" diameter="1.9304"/>
+<pad name="GND@2" x="13.97" y="2.54" drill="0.8" diameter="1.9304"/>
+<pad name="D5" x="13.97" y="0" drill="0.8" diameter="1.9304"/>
+<pad name="D6" x="13.97" y="-2.54" drill="0.8" diameter="1.9304"/>
+<pad name="D7" x="13.97" y="-5.08" drill="0.8" diameter="1.9304"/>
+<pad name="D8" x="13.97" y="-7.62" drill="0.8" diameter="1.9304"/>
+<pad name="RX" x="13.97" y="-10.16" drill="0.8" diameter="1.9304"/>
+<pad name="TX" x="13.97" y="-12.7" drill="0.8" diameter="1.9304"/>
+<pad name="GND@3" x="13.97" y="-15.24" drill="0.8" diameter="1.9304"/>
+<pad name="3V3@2" x="13.97" y="-17.78" drill="0.8" diameter="1.9304"/>
+<wire x1="-7.62" y1="25.04" x2="-7.62" y2="2.54" width="0.2032" layer="51"/>
+<wire x1="-7.62" y1="2.54" x2="7.62" y2="2.54" width="0.2032" layer="51"/>
+<wire x1="7.62" y1="2.54" x2="7.62" y2="25.04" width="0.2032" layer="51"/>
+<wire x1="-3.81" y1="-21.59" x2="-3.81" y2="-16.51" width="0.2032" layer="51"/>
+<wire x1="-3.81" y1="-16.51" x2="3.81" y2="-16.51" width="0.2032" layer="51"/>
+<wire x1="3.81" y1="-16.51" x2="3.81" y2="-21.59" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="20,32" x2="-5.08" y2="24.13" width="0.2032" layer="51"/>
+<wire x1="-5.08" y1="24.13" x2="-3.81" y2="24.13" width="0.2032" layer="51"/>
+<wire x1="-3.81" y1="24.13" x2="-3.81" y2="21.59" width="0.2032" layer="51"/>
+<wire x1="-3.81" y1="21.59" x2="-2.54" y2="21.59" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="21.59" x2="-2.54" y2="24.13" width="0.2032" layer="51"/>
+<wire x1="-2.54" y1="24.13" x2="-1.27" y2="24.13" width="0.2032" layer="51"/>
+<wire x1="-1.27" y1="24.13" x2="-1.27" y2="21.59" width="0.2032" layer="51"/>
+<wire x1="-1.27" y1="21.59" x2="0" y2="21.59" width="0.2032" layer="51"/>
+<wire x1="0" y1="21.59" x2="0" y2="24.13" width="0.2032" layer="51"/>
+<wire x1="0" y1="24.13" x2="1.27" y2="24.13" width="0.2032" layer="51"/>
+<wire x1="1.27" y1="24.13" x2="1.27" y2="21.59" width="0.2032" layer="51"/>
+<wire x1="1.27" y1="21.59" x2="2.54" y2="21.59" width="0.2032" layer="51"/>
+<wire x1="2.54" y1="21.59" x2="2.54" y2="24.13" width="0.2032" layer="51"/>
+<wire x1="2.54" y1="24.13" x2="5.08" y2="24.13" width="0.2032" layer="51"/>
+<wire x1="-8.89" y1="-16.51" x2="-6.35" y2="-16.51" width="0.2032" layer="51"/>
+<wire x1="-6.35" y1="-16.51" x2="-6.35" y2="-20.32" width="0.2032" layer="51"/>
+<wire x1="-6.35" y1="-20.32" x2="-8.89" y2="-20.32" width="0.2032" layer="51"/>
+<wire x1="-8.89" y1="-20.32" x2="-8.89" y2="-16.51" width="0.2032" layer="51"/>
+<wire x1="6.35" y1="-16.51" x2="6.35" y2="-20.32" width="0.2032" layer="51"/>
+<wire x1="6.35" y1="-20.32" x2="8.89" y2="-20.32" width="0.2032" layer="51"/>
+<wire x1="8.89" y1="-20.32" x2="8.89" y2="-16.51" width="0.2032" layer="51"/>
+<wire x1="8.89" y1="-16.51" x2="6.35" y2="-16.51" width="0.2032" layer="51"/>
+<text x="-12.7" y="17.78" size="0.8128" layer="51">A0</text>
+<text x="-12.7" y="15.24" size="0.8128" layer="51">RSV</text>
+<text x="-12.7" y="12.7" size="0.8128" layer="51">RSV</text>
+<text x="-12.7" y="10.16" size="0.8128" layer="51">RSV</text>
+<text x="-12.7" y="7.62" size="0.8128" layer="51">RSV</text>
+<text x="-12.7" y="5.08" size="0.8128" layer="51">RSV</text>
+<text x="-12.7" y="2.54" size="0.8128" layer="51">RSV</text>
+<text x="-12.7" y="0" size="0.8128" layer="51">GND</text>
+<text x="-12.7" y="-2.54" size="0.8128" layer="51">3V3</text>
+<text x="-12.7" y="-5.08" size="0.8128" layer="51">GND</text>
+<text x="-12.7" y="-7.62" size="0.8128" layer="51">3V3</text>
+<text x="-12.7" y="-10.16" size="0.8128" layer="51">EN</text>
+<text x="-12.7" y="-12.7" size="0.8128" layer="51">RST</text>
+<text x="-12.7" y="-15.24" size="0.8128" layer="51">GND</text>
+<text x="-12.7" y="-17.78" size="0.8128" layer="51">5V</text>
+<text x="12.7" y="-17.78" size="0.8128" layer="51" align="bottom-right">3V3</text>
+<text x="12.7" y="-15.24" size="0.8128" layer="51" align="bottom-right">GND</text>
+<text x="12.7" y="-12.7" size="0.8128" layer="51" align="bottom-right">TX</text>
+<text x="12.7" y="-10.16" size="0.8128" layer="51" align="bottom-right">RX</text>
+<text x="12.7" y="-7.62" size="0.8128" layer="51" align="bottom-right">~D8</text>
+<text x="12.7" y="-5.08" size="0.8128" layer="51" align="bottom-right">~D7</text>
+<text x="12.7" y="-2.54" size="0.8128" layer="51" align="bottom-right">~D6</text>
+<text x="12.7" y="0" size="0.8128" layer="51" align="bottom-right">~D5</text>
+<text x="12.7" y="2.54" size="0.8128" layer="51" align="bottom-right">GND</text>
+<text x="12.7" y="5.08" size="0.8128" layer="51" align="bottom-right">3V3</text>
+<text x="12.7" y="7.62" size="0.8128" layer="51" align="bottom-right">~D4</text>
+<text x="12.7" y="10.16" size="0.8128" layer="51" align="bottom-right">~D3</text>
+<text x="12.7" y="12.7" size="0.8128" layer="51" align="bottom-right">~D2</text>
+<text x="12.7" y="15.24" size="0.8128" layer="51" align="bottom-right">~D1</text>
+<text x="12.7" y="17.78" size="0.8128" layer="51" align="bottom-right">D0</text>
+<text x="-2.54" y="-15.24" size="1.778" layer="25" rot="R90">&gt;NAME</text>
+<text x="3.81" y="-15.24" size="1.778" layer="27" rot="R90">&gt;VALUE</text>
+</package>
+</packages>
+<symbols>
+<symbol name="ESP12_DEVKIT">
+<description>ESP12_DEVKIT</description>
+<pin name="A0" x="-20.32" y="17.78" visible="pin" length="middle"/>
+<pin name="RSV@0" x="-20.32" y="15.24" visible="pin" length="middle"/>
+<pin name="RSV@1" x="-20.32" y="12.7" visible="pin" length="middle"/>
+<pin name="RSV@2" x="-20.32" y="10.16" visible="pin" length="middle"/>
+<pin name="RSV@3" x="-20.32" y="7.62" visible="pin" length="middle"/>
+<pin name="RSV@4" x="-20.32" y="5.08" visible="pin" length="middle"/>
+<pin name="RSV@5" x="-20.32" y="2.54" visible="pin" length="middle"/>
+<pin name="GND@4" x="-20.32" y="0" visible="pin" length="middle"/>
+<pin name="3V3@3" x="-20.32" y="-2.54" visible="pin" length="middle"/>
+<pin name="GND@0" x="-20.32" y="-5.08" visible="pin" length="middle"/>
+<pin name="3V3@0" x="-20.32" y="-7.62" visible="pin" length="middle"/>
+<pin name="EN" x="-20.32" y="-10.16" visible="pin" length="middle"/>
+<pin name="RST" x="-20.32" y="-12.7" visible="pin" length="middle"/>
+<pin name="GND@1" x="-20.32" y="-15.24" visible="pin" length="middle"/>
+<pin name="5V" x="-20.32" y="-17.78" visible="pin" length="middle"/>
+<pin name="D0" x="20.32" y="17.78" visible="pin" length="middle" rot="R180"/>
+<pin name="D1" x="20.32" y="15.24" visible="pin" length="middle" rot="R180"/>
+<pin name="D2" x="20.32" y="12.7" visible="pin" length="middle" rot="R180"/>
+<pin name="D3" x="20.32" y="10.16" visible="pin" length="middle" rot="R180"/>
+<pin name="D4" x="20.32" y="7.62" visible="pin" length="middle" rot="R180"/>
+<pin name="3V3@1" x="20.32" y="5.08" visible="pin" length="middle" rot="R180"/>
+<pin name="GND@2" x="20.32" y="2.54" visible="pin" length="middle" rot="R180"/>
+<pin name="D5" x="20.32" y="0" visible="pin" length="middle" rot="R180"/>
+<pin name="D6" x="20.32" y="-2.54" visible="pin" length="middle" rot="R180"/>
+<pin name="D7" x="20.32" y="-5.08" visible="pin" length="middle" rot="R180"/>
+<pin name="D8" x="20.32" y="-7.62" visible="pin" length="middle" rot="R180"/>
+<pin name="RX" x="20.32" y="-10.16" visible="pin" length="middle" rot="R180"/>
+<pin name="TX" x="20.32" y="-12.7" visible="pin" length="middle" rot="R180"/>
+<pin name="GND@3" x="20.32" y="-15.24" visible="pin" length="middle" rot="R180"/>
+<pin name="3V3@2" x="20.32" y="-17.78" visible="pin" length="middle" rot="R180"/>
+<wire x1="-15.24" y1="25.04" x2="-15.24" y2="-21.59" width="0.254" layer="94"/>
+<wire x1="-15.24" y1="-21.59" x2="15.24" y2="-21.59" width="0.254" layer="94"/>
+<wire x1="15.24" y1="-21.59" x2="15.24" y2="25.04" width="0.254" layer="94"/>
+<wire x1="15.24" y1="25.04" x2="-15.24" y2="25.04" width="0.254" layer="94"/>
+<text x="-15.24" y="25.29" size="1.778" layer="95">&gt;NAME</text>
+<text x="-15.24" y="-24.13" size="1.778" layer="96">&gt;VALUE</text>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="ESP12_DEVKIT">
+<description>ESP12 DEVKIT BOARD</description>
+<gates>
+<gate name="G$1" symbol="ESP12_DEVKIT" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="ESP12_DEVKIT">
+<connects>
+<connect gate="G$1" pin="3V3@0" pad="3V3@0"/>
+<connect gate="G$1" pin="3V3@1" pad="3V3@1"/>
+<connect gate="G$1" pin="3V3@2" pad="3V3@2"/>
+<connect gate="G$1" pin="3V3@3" pad="3V3@3"/>
+<connect gate="G$1" pin="A0" pad="A0"/>
+<connect gate="G$1" pin="D0" pad="D0"/>
+<connect gate="G$1" pin="D1" pad="D1"/>
+<connect gate="G$1" pin="D2" pad="D2"/>
+<connect gate="G$1" pin="D3" pad="D3"/>
+<connect gate="G$1" pin="D4" pad="D4"/>
+<connect gate="G$1" pin="D5" pad="D5"/>
+<connect gate="G$1" pin="D6" pad="D6"/>
+<connect gate="G$1" pin="D7" pad="D7"/>
+<connect gate="G$1" pin="D8" pad="D8"/>
+<connect gate="G$1" pin="EN" pad="EN"/>
+<connect gate="G$1" pin="GND@0" pad="GND@0"/>
+<connect gate="G$1" pin="GND@1" pad="GND@1"/>
+<connect gate="G$1" pin="GND@2" pad="GND@2"/>
+<connect gate="G$1" pin="GND@3" pad="GND@3"/>
+<connect gate="G$1" pin="GND@4" pad="GND@4"/>
+<connect gate="G$1" pin="RST" pad="RST"/>
+<connect gate="G$1" pin="RSV@0" pad="RSV@0"/>
+<connect gate="G$1" pin="RSV@1" pad="RSV@1"/>
+<connect gate="G$1" pin="RSV@2" pad="RSV@2"/>
+<connect gate="G$1" pin="RSV@3" pad="RSV@3"/>
+<connect gate="G$1" pin="RSV@4" pad="RSV@4"/>
+<connect gate="G$1" pin="RSV@5" pad="RSV@5"/>
+<connect gate="G$1" pin="RX" pad="RX"/>
+<connect gate="G$1" pin="TX" pad="TX"/>
+<connect gate="G$1" pin="5V" pad="5V"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+</drawing>
+</eagle>


### PR DESCRIPTION
The file is based on the Eagle library available for v1.0 (https://github.com/nodemcu/nodemcu-devkit-v1.0).

Although the v0.9 board is outdated, it is currently still actively sold on the internet. 
I thought the file might be usefully added to the repo.